### PR TITLE
Fix exception when PortSpecs is = null

### DIFF
--- a/bin/mesos-docker
+++ b/bin/mesos-docker
@@ -110,6 +110,7 @@ class DockerExecutor(mesos.Executor):
             exit(2)
         self.task   = task
         self.driver = driver
+        log.info(os.environ)
         log.info('Task is: %s' % task.task_id.value)
         try:
             self.data = json.loads(task.data) if task.data else {}
@@ -218,8 +219,10 @@ def run_with_env_PORT(image, args=[], env={},
     for k, v in env.items():
         cmd += [ '-e', '%s=%s' % (k,v) ]
     port = principal_port(image)
-    if port and 'PORT' in os.environ:
-        port_mapping   = os.environ['PORT'] + ":" + str(int(port))
+    log.info("port %s" % port)
+    log.info("PORTS %s" % os.environ['PORTS'])
+    if port and 'PORTS' in os.environ:
+        port_mapping   = os.environ['PORTS'] + ":" + str(int(port))
         cmd           += [ '-p', port_mapping ]
     argv = ['docker'] + cmd + [ image ] + [ arg for arg in args ]
     log.info('ARGV ' + ' '.join(str(arg) for arg in argv))
@@ -235,8 +238,8 @@ def principal_port(image):
     if 'config' in parsed and config is None:
         config = parsed['config']
 
-    if config and config['PortSpecs']:
-        port = config['PortSpecs'][0].split(':')[-1]
+    if config and config['ExposedPorts']:
+        port = config['ExposedPorts'].keys()[0].split('/')[0]
     else:
         port = None 
     return port

--- a/bin/mesos-docker
+++ b/bin/mesos-docker
@@ -234,7 +234,11 @@ def principal_port(image):
         config = parsed['Config']
     if 'config' in parsed and config is None:
         config = parsed['config']
-    port   = config['PortSpecs'][0].split(':')[-1] if config else None
+
+    if config and config['PortSpecs']:
+        port = config['PortSpecs'][0].split(':')[-1]
+    else:
+        port = None 
     return port
 
 def pull(image):


### PR DESCRIPTION
If you create an image where PortSpecs is null, the executor will throw an exception after doing a docker inspect. This will set port to None if the image's PortSpecs is null. 

Example config that causes the issue:

```
"config": {
        "Hostname": "2f3c78ed5540",
        "Domainname": "",
        "User": "",
        "Memory": 0,
        "MemorySwap": 0,
        "CpuShares": 0,
        "AttachStdin": false,
        "AttachStdout": false,
        "AttachStderr": false,
        "PortSpecs": null,
        "ExposedPorts": null,
        "Tty": false,
        "OpenStdin": false,
        "StdinOnce": false,
        "Env": [
            "HOME=/",
            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
        ],
        "Cmd": null,
        "Dns": null,
        "Image": "27eb999a2f541a0243ba3168ec3778533d4e1b73c8e34727d77956b6f2fa6d95",
        "Volumes": null,
        "VolumesFrom": "",
        "WorkingDir": "",
        "Entrypoint": null,
        "NetworkDisabled": false
    },
```
