### PR TITLE
use ExposedPorts as principal_port

### DIFF
--- a/bin/mesos-docker
+++ b/bin/mesos-docker
@@ -234,7 +234,12 @@ def principal_port(image):
         config = parsed['Config']
     if 'config' in parsed and config is None:
         config = parsed['config']
-    port   = config['PortSpecs'][0].split(':')[-1] if config else None
+    port = None
+    if config:
+        if config['ExposedPorts']:
+            port = config['ExposedPorts'].keys()[0].split('/')[0]
+        elif config['PortSpecs']:
+            port = config['PortSpecs'][0].split(':')[-1]
     return port
 
 def pull(image):


### PR DESCRIPTION
Hi,

I found that some Docker images have only `ExposedPorts`, no `PortSpecs`; for example when I build a custom image using `Dockerfile` containing `EXPOSE ***`.

This patch is for these images. If there is no `PortSpecs` but `ExposedPorts`, the executer uses later it as a `principal_port`.

Thanks,
riywo
