### PR TITLE
Log to stdout rather than syslog

### DIFF
--- a/bin/mesos-docker
+++ b/bin/mesos-docker
@@ -42,10 +42,10 @@ def read_cid():
 
 log    = logging.getLogger(os.path.basename(sys.argv[0]))
 log.setLevel(logging.DEBUG)
-syslog = logging.handlers.SysLogHandler(address = '/dev/log')
-syslog_format = logging.Formatter("%(name)s[%(process)d]: %(message)s")
-syslog.setFormatter(syslog_format)
-log.addHandler(syslog)
+stdout = logging.StreamHandler(sys.stdout)
+stdout_format = logging.Formatter("%(name)s[%(process)d]: %(message)s")
+stdout.setFormatter(stdout_format)
+log.addHandler(stdout)
 
 class DockerExecutor(mesos.Executor):
     def __init__(self, args):


### PR DESCRIPTION
Logging to syslog were problematic while running Mesos-slave inside Docker container.
Because best practice with Docker is that you run only one process in the container, but logging to syslog require that also syslog daemon is running in the container.
I also liked that now I can see the log output through Mesos UI.

I'm not expert with this so what do you think, should we change logging to stdout (for instance this suggest to do so http://12factor.net/logs) or should we log to syslog?
