### PR TITLE
Replace check_output() by Popen() for better compatibility.

### DIFF
--- a/bin/mesos-docker
+++ b/bin/mesos-docker
@@ -244,7 +244,7 @@ def run_with_settings(image, args=[], env={}, ports=[],
 
 @ensure_image
 def inner_ports(image):
-    text   = subprocess.check_output(['docker', 'inspect', image])
+    text   = subprocess.Popen(['docker', 'inspect', image], stdout=subprocess.PIPE).communicate()[0]
     parsed = json.loads(text)[0]
     config = None
     if 'Config' in parsed:
@@ -277,7 +277,7 @@ def image_info(image):
 images = {}
 def refresh_docker_image_info(image):
     delim   = re.compile('  +')
-    text    = subprocess.check_output(['docker', 'images', image])
+    text    = subprocess.Popen(['docker', 'images', image], stdout=subprocess.PIPE).communicate()[0]
     records = [ delim.split(line) for line in text.splitlines() ]
     for record in records:
         if record[0] == image:


### PR DESCRIPTION
subprocess.check_output() was introduced in python 2.7.
In python 2.6 environment like RHEL/CentOS 6.x, execution of mesos-docker fails with this error:

```
AttributeError: 'module' object has no attribute 'check_output'
```

This patch replaces check_output() by Popen() for better compatibility.

Tested on CentOS 6.5 x86_64 / Python 2.6.6 / Docker 0.7.2 / Mesos 0.16.0-rc2 .
