### PR TITLE
Add check_output() for python 2.6 or earlier.

### DIFF
--- a/bin/mesos-docker
+++ b/bin/mesos-docker
@@ -243,6 +243,19 @@ def run_with_settings(image, args=[], env={}, ports=[],
     log.info('ARGV ' + ' '.join(str(arg) for arg in argv))
     return subprocess.Popen(argv)
 
+try:
+    subprocess.check_output
+except:
+    # For python 2.6 or earlier.
+    def check_output(*args):
+        p = subprocess.Popen(stdout=subprocess.PIPE, *args)
+        stdout = p.communicate()[0]
+        exitcode = p.wait()
+        if exitcode:
+            raise subprocess.CalledProcessError(exitcode, args[0])
+        return stdout
+    subprocess.check_output = check_output
+
 @ensure_image
 def inner_ports(image):
     text   = subprocess.check_output(['docker', 'inspect', image])


### PR DESCRIPTION
subprocess.check_output() was introduced in python 2.7.
In python 2.6 environment like RHEL/CentOS 6.x, execution of mesos-docker fails with this error:

```
AttributeError: 'module' object has no attribute 'check_output'
```

This patch adds check_output() for python 2.6 or earlier.

Tested on CentOS 6.5 x86_64 / Python 2.6.6 / Docker 0.7.2 / Mesos 0.16.0-rc2 .
