### PR TITLE
Properly calculate memory requirements

### DIFF
--- a/bin/mesos-docker
+++ b/bin/mesos-docker
@@ -73,7 +73,7 @@ class DockerExecutor(mesos.Executor):
             cpus = [ r.scalar.value for r in resources if r.name == 'cpus' ]
             megs = [ r.scalar.value for r in resources if r.name == 'mem' ]
             relative_cpu = [ int(256 * r)     for r in cpus ] + [ None ]
-            memory_bytes = [ int((2**30) * r) for r in megs ] + [ None ]
+            memory_bytes = [ int((2**20) * r) for r in megs ] + [ None ]
             ports = self.allocated_ports()
             proc = run_with_settings(self.image, self.docker_options,
                                      args, self.env, ports,


### PR DESCRIPTION
The memory requirements passed to docker are being calculated incorrectly. Megabytes to bytes is 2^20, not 2^30.
